### PR TITLE
Adds authorization header

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class Arena {
     };
     if (opts.accessToken) {
       headers['X-AUTH-TOKEN'] = opts.accessToken;
+      headers['Authorization'] = `Bearer ${opts.accessToken}`;
     }
     this.axios = axios.create({
       baseURL: opts.baseURL || 'https://api.are.na/v2/',


### PR DESCRIPTION
### Description

This PR adds an authorization header reverted by this [pull request](https://github.com/ivangreene/arena-js/pull/6). In my tests, without this fix is not possible to access to private channels. 

### How Has This Been Tested?

I created a private channel in my are.na account and attempted to retrieve their blocks. Without the fix I got a `401: Unauthorized` error response.

The current are.na ruby gem [works using the proposed header](https://github.com/aredotna/arena-rb/blob/eda7a0c4ed96e46b07e1ef0842a2287efbe7d5d0/lib/arena/client.rb#L33).