### PR TITLE
Fix param assignment for non-post requests and header content type

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class Arena {
   constructor(opts) {
     opts = opts || {};
     let headers = {
-      "Content-Type": "application/x-www-form-urlencoded"
+      "Content-Type": "application/json"
     };
     if (opts.accessToken) {
       headers["Authorization"] = `Bearer ${opts.accessToken}`;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const axios = require("axios");
-const qs = require("qs");
 
 // Helper to deal with pulling an inner object out of returned data
 // and then assigning other data as "attrs"
@@ -30,21 +29,29 @@ class Arena {
     if (opts.accessToken) {
       headers["Authorization"] = `Bearer ${opts.accessToken}`;
     }
+    if (opts.authToken) {
+      headers["X-AUTH-TOKEN"] = `${opts.authToken}`;
+    }
     this.axios = axios.create({
       baseURL: opts.baseURL || "https://api.are.na/v2/",
       headers
     });
     this.requestHandler =
       opts.requestHandler ||
-      ((method, url, data) =>
-        this.axios.request({ method, url, data }).then(({ data }) => data));
+      ((method, url, data) => {
+        return method === "get"
+          ? this.axios
+              .request({ method, url, params: data })
+              .then(({ data }) => data)
+          : this.axios.request({ method, url, data }).then(({ data }) => data);
+      });
   }
 
   _req(method, url, ...data) {
     return this.requestHandler(
       method.toLowerCase(),
       url,
-      qs.stringify(Object.assign({}, ...data), { indices: false })
+      Object.assign({}, ...data)
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "are.na",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Interface to are.na API",
   "main": "index.js",
   "files": [

--- a/test/Arena.test.js
+++ b/test/Arena.test.js
@@ -5,12 +5,14 @@ const path = require("path");
 chai.use(require("chai-as-promised"));
 chai.use(require("sinon-chai"));
 const expect = chai.expect;
+const qs = require("qs");
 
 const Arena = require("../");
 let arena, requestHandler;
 
 beforeEach(function() {
-  requestHandler = sinon.spy(function(method, url, data) {
+  requestHandler = sinon.spy(function(method, url, ...data) {
+    const params = qs.stringify(Object.assign({}, ...data), { indices: false });
     return new Promise((resolve, reject) => {
       fs.readFile(
         path.join(
@@ -18,7 +20,7 @@ beforeEach(function() {
           "staged",
           method,
           "api.are.na/v2",
-          url.replace(/\/$/, "") + "?" + data
+          url.replace(/\/$/, "") + "?" + params
         ),
         "utf8",
         (err, data) => {
@@ -42,11 +44,10 @@ describe("Arena", function() {
         expect(
           arena.channel().get({ page: 3, per: 10 })
         ).to.eventually.have.property("channels"),
-        expect(requestHandler).to.have.been.calledWith(
-          "get",
-          "channels/",
-          "page=3&per=10"
-        )
+        expect(requestHandler).to.have.been.calledWith("get", "channels/", {
+          page: 3,
+          per: 10
+        })
       ]);
     });
   });
@@ -169,18 +170,18 @@ describe("Arena", function() {
     it(".all() should search for query", function() {
       return Promise.all([
         expect(search.all()).to.eventually.be.an("object"),
-        expect(requestHandler).to.have.been.calledWith("get", "search", "q=art")
+        expect(requestHandler).to.have.been.calledWith("get", "search", {
+          q: "art"
+        })
       ]);
     });
 
     it(".users() should search for users", function() {
       return Promise.all([
         expect(search.users()).to.eventually.be.an("array"),
-        expect(requestHandler).to.have.been.calledWith(
-          "get",
-          "search/users",
-          "q=art"
-        )
+        expect(requestHandler).to.have.been.calledWith("get", "search/users", {
+          q: "art"
+        })
       ]);
     });
 
@@ -190,7 +191,7 @@ describe("Arena", function() {
         expect(requestHandler).to.have.been.calledWith(
           "get",
           "search/channels",
-          "q=art"
+          { q: "art" }
         )
       ]);
     });
@@ -198,11 +199,9 @@ describe("Arena", function() {
     it(".blocks() should search for blocks", function() {
       return Promise.all([
         expect(search.blocks()).to.eventually.be.an("array"),
-        expect(requestHandler).to.have.been.calledWith(
-          "get",
-          "search/blocks",
-          "q=art"
-        )
+        expect(requestHandler).to.have.been.calledWith("get", "search/blocks", {
+          q: "art"
+        })
       ]);
     });
   });


### PR DESCRIPTION
1. Lets `axios` handle get params
2. Passes POST params as data
3. Fixes content header type

Shoutout to @callil for the original approach!