### PR TITLE
Fix to createBlock function + Add /me endpoint

### DIFF
--- a/examples/me.js
+++ b/examples/me.js
@@ -1,0 +1,6 @@
+const Arena = require('../');
+let arena = new Arena({
+    accessToken: process.env.ARENA_ACCESS_TOKEN
+});
+
+arena.me().get().then(user => console.log(user.full_name));

--- a/index.js
+++ b/index.js
@@ -122,8 +122,11 @@ class Arena {
         }).then(pullObject("users")),
 
       createBlock: (opts) => {
-        if (opts.content.match(/^https?:\/\//)) {
-          opts.source = opts.content;
+        if(typeof opts !== 'object' && opts !== null) {
+          opts = {
+            source: opts.match(/^https?:\/\//) ? opts : '',
+            content: !opts.match(/^https?:\/\//) ? opts : ''
+          }
         }
         return this._req("POST", "channels/" + slug + "/blocks", opts);
       },

--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ class Arena {
       ((method, url, data) => {
         return method === "get"
           ? this.axios
-              .request({ method, url, params: data })
-              .then(({ data }) => data)
+            .request({ method, url, params: data })
+            .then(({ data }) => data)
           : this.axios.request({ method, url, data }).then(({ data }) => data);
       });
   }
@@ -170,6 +170,12 @@ class Arena {
           pullObject("users")
         ),
     };
+  }
+
+  me() {
+    return {
+      get: () => this._req("GET", "me/")
+    }
   }
 
   search(q, data) {


### PR DESCRIPTION
Using the createBlock as documented in the README would throw an exception as passing a string through would break the regex.

I added a small check to see whether the parameter was an object first, if not it will create one and use the regex.

The README may need some updating too as you can pass in an object with title, description etc and that will work as is.

Edit: Added an additional function to facilitate the `/me` API endpoint
